### PR TITLE
Implement unified fetch wrapper

### DIFF
--- a/src/services/linkService.ts
+++ b/src/services/linkService.ts
@@ -4,7 +4,7 @@ import { fetchWithFirebaseRetry } from '@/lib/utils/fetchWithAuthRetry';
 export const LinkService = {
   async createLink({ title, url, description, image, favicon, folderId }: CreateLinkInput): Promise<Link> {
     try {
-      const res = await fetchWithFirebaseRetry('/api/links', {
+      const json = await fetchWithFirebaseRetry<{ success: boolean; link: Link }>('/api/links', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -17,15 +17,6 @@ export const LinkService = {
           folderId,
         }),
       });
-
-      const json = await res.json();
-
-      if (!res.ok || !json.success) {
-        const errorText = await res.text();
-        console.error('❌ 링크 생성 실패:', errorText);
-        throw new Error(errorText || '링크 생성 실패');
-      }
-
       return json.link as Link;
     } catch (err) {
       console.error('🔥 링크 생성 중 예외 발생:', err);
@@ -34,32 +25,18 @@ export const LinkService = {
   },
 
   async deleteLink(linkId: string): Promise<void> {
-    const res = await fetch(`/api/links/${linkId}`, {
+    await fetchWithFirebaseRetry<void>(`/api/links/${linkId}`, {
       method: 'DELETE',
       credentials: 'include',
     });
-
-    if (!res.ok) {
-      throw new Error((await res.text()) || '링크 삭제 실패');
-    }
   },
   async getLinkById(linkId: string): Promise<Link> {
-    console.log('서비스', linkId);
     try {
-      const res = await fetchWithFirebaseRetry(`/api/links/${linkId}`, {
+      const json = await fetchWithFirebaseRetry<{ success: boolean; link: Link }>(`/api/links/${linkId}`, {
         method: 'GET',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
       });
-
-      const json = await res.json();
-      console.log('성공', json);
-      if (!res.ok || !json.success) {
-        const errorText = json?.message || '링크 조회 실패';
-        console.error('❌ 링크 조회 실패:', errorText);
-        throw new Error(errorText);
-      }
-
       return json.link as Link;
     } catch (err) {
       console.error('🔥 링크 조회 중 예외 발생:', err);
@@ -68,19 +45,12 @@ export const LinkService = {
   },
   async updateLink(linkId: string, data: Partial<Pick<Link, 'title' | 'description' | 'isPin'>>): Promise<Link> {
     try {
-      const res = await fetch(`/api/links/${linkId}`, {
+      const json = await fetchWithFirebaseRetry<{ success: boolean; link: Link }>(`/api/links/${linkId}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
         body: JSON.stringify(data),
       });
-
-      const json = await res.json();
-      if (!res.ok || !json.success) {
-        const errorText = await res.text();
-        console.error('❌ 링크 수정 실패:', errorText);
-        throw new Error(errorText || '링크 수정 실패');
-      }
 
       return json.link as Link;
     } catch (err) {


### PR DESCRIPTION
## Summary
- add generic return and response handling to `fetchWithFirebaseRetry`
- remove duplicated error checks in `LinkService` and `FolderService`
- type service calls with expected API responses
- use `unknown` rather than `any` as default generic
- specify `<void>` for calls without a return value

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c7b20f864832496770d43aa03eb69